### PR TITLE
Use constexpr instead of #define

### DIFF
--- a/SSKeyboard/include/sskeyboard.h
+++ b/SSKeyboard/include/sskeyboard.h
@@ -15,20 +15,20 @@
 #include <stdlib.h>
 
 /// Package size for Feature and Output Request
-#define kPackageSize     0x20c   /// 524
-#define kOutputPackageSize      0x40    /// 64
+constexpr uint32_t kPackageSize = 0x20c;   /// 524
+constexpr uint8_t kOutputPackageSize = 0x40;    /// 64
 
 /// Per-Key & GS65 Matching
-#define kVendorId               0x1038  /// 4152
-#define kProductId              0x1122  /// 4386
-#define kMaxFeatureReportSize   0x20c   /// 524
-#define kPrimaryUsagePage       0xffc0  /// 65472
+constexpr uint32_t kVendorId = 0x1038;  /// 4152
+constexpr uint32_t kProductId = 0x1122;  /// 4386
+constexpr uint32_t kMaxFeatureReportSize = 0x20c;   /// 524
+constexpr uint32_t kPrimaryUsagePage = 0xffc0;  /// 65472
 
 /// GS65 Matching
-#define kGS65VersionNumber      0x229   /// 553
+constexpr uint32_t kGS65VersionNumber = 0x229;  /// 553
 
 /// Per-Key Matching
-#define kPerKeyVersionNumber    0x230   /// 560
+constexpr uint32_t kPerKeyVersionNumber = 0x230;   /// 560
 
 /// TODO Three Region Matching
 

--- a/SSKeyboard/include/sskeys.h
+++ b/SSKeyboard/include/sskeys.h
@@ -13,16 +13,16 @@
 #include <stdint.h>
 
 /// Size of regions
-#define kRegions            0x04    /// 4
+constexpr uint8_t kRegions = 0x04;    /// 4
 
 /// Size of keys - GS65
-#define kModifiersSize      0x18    /// 24
-#define kAlphanumsSize      0x2a    /// 42
-#define kEnterSize          0xb     /// 11
-#define kSpecialSize        0x13    /// 19
+constexpr uint8_t kModifiersSize = 0x18;    /// 24
+constexpr uint8_t kAlphanumsSize = 0x2a;    /// 42
+constexpr uint8_t kEnterSize = 0xb;     /// 11
+constexpr uint8_t kSpecialSize = 0x13;    /// 19
 
 /// Size of keys - PerKey
-#define kSpecialPerKeySize  0x24    /// 36
+constexpr uint8_t kSpecialPerKeySize = 0x24;    /// 36
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
You know, `#define` is just very 1990s and modern `constexpr` should be used.